### PR TITLE
Fix for compliance and process observability bugs

### DIFF
--- a/default/data/ui/views/compliance_controls.xml
+++ b/default/data/ui/views/compliance_controls.xml
@@ -14,7 +14,7 @@
       <fieldForLabel>ClusterName</fieldForLabel>
       <fieldForValue>ClusterName</fieldForValue>
       <search>
-        <query>Type="MatchedPolicy" ClusterName="*"
+        <query>index="*" Type="MatchedPolicy" OR Type="MatchedHostPolicy" ClusterName="*"
 | table ClusterName
 | dedup ClusterName</query>
         <earliest>0</earliest>
@@ -31,8 +31,8 @@
       <fieldForLabel>HostName</fieldForLabel>
       <fieldForValue>HostName</fieldForValue>
       <search>
-        <query>Type="MatchedPolicy" OR Type="MatchedHostPolicy" HostName="*" ClusterName=$ClusterName$
-| table HostName 
+        <query>index="*" Type="MatchedPolicy" OR Type="MatchedHostPolicy" HostName="*" ClusterName=$ClusterName$
+| table HostName
 | dedup HostName</query>
         <earliest>0</earliest>
         <latest></latest>

--- a/default/data/ui/views/process_observability.xml
+++ b/default/data/ui/views/process_observability.xml
@@ -14,7 +14,7 @@
       <title>Top 5 Most Executed Processes Per Host</title>
       <chart>
         <search>
-          <query>index=cwpp sourcetype=* operation="process"
+          <query>index=* sourcetype=* operation="process"
 | stats count by process_file.source host
 | sort -count
 | head 5
@@ -68,7 +68,7 @@
       <title>Top Executed Processes and File Access Patterns Across Hosts</title>
       <table>
         <search>
-          <query>index=cwpp sourcetype=* 
+          <query>index=* sourcetype=* 
 | stats count by _time host operation process_file.source process_file.destination process_file.count action
 | sort -count</query>
           <earliest>$timestamp.earliest$</earliest>


### PR DESCRIPTION
This PR addresses the following 2 bugs:

- In the Process Observability dashboard, the index was hardcoded to cwpp. All other dashboards use * for every query. While I don't think is efficient, and we should eventually find a way to get the index name from the user, I'll set it to * for now to keep things consistent.
- The cluster name and hostname filters aren't working in the Compliance dashboard.